### PR TITLE
Fix test statement

### DIFF
--- a/plugin/backupdmm.sh
+++ b/plugin/backupdmm.sh
@@ -201,7 +201,7 @@ checkbinary $UBINIZE
 echo -n $WHITE
 #############################################################################
 # TEST IF RECEIVER IS SUPPORTED #
-if [ -f /etc/modules-load.d/*dreambox-dvb-modules*.conf ] ; then
+if ls /etc/modules-load.d/*dreambox-dvb-modules*.conf >/dev/null 2>&1 ; then
 	if [ -f /proc/enigma/model ] && [ -s /proc/enigma/model ] ; then
 		log "Lets read enigma module proc entries"
 		SEARCH=$( cat /proc/enigma/model )

--- a/plugin/backupsuite.sh
+++ b/plugin/backupsuite.sh
@@ -188,7 +188,7 @@ checkbinary $UBINIZE
 echo -n $WHITE
 #############################################################################
 # TEST IF RECEIVER IS SUPPORTED #
-if [ -f /etc/modules-load.d/*dreambox-dvb-modules*.conf ] ; then
+if ls /etc/modules-load.d/*dreambox-dvb-modules*.conf >/dev/null 2>&1 ; then
 	log "It's a dreambox! Not compatible with this script."
 	exit 1
 else


### PR DESCRIPTION
Update test statement to avoid errors when there is more than one file in /etc/modules-load.d/*dreambox-dvb-modules*.conf.